### PR TITLE
Use the 2.7 virtualenv script instead...

### DIFF
--- a/playbooks/includes/django-managed-post-checkout.yml
+++ b/playbooks/includes/django-managed-post-checkout.yml
@@ -1,5 +1,5 @@
     - name: Create a virtualenv for the build
-      command: virtualenv -p {{ python_interpreter|default('python2.6') }} {{ base_dir }}/builds/{{current_build_value}}
+      command: /usr/local/bin/virtualenv-2.7 -p {{ python_interpreter|default('python2.6') }} {{ base_dir }}/builds/{{current_build_value}}
 
     - name: Copy over requirements for the project level
       copy: src="{{ files_dir }}/project_requirements.txt" dest="{{ base_dir }}/project_requirements.txt" group="{{ file_group }}" mode="0664"


### PR DESCRIPTION
setuptools 30.2.0 breaks creating a 2.7 env with the 2.6 script, and the reverse works just fine.