### PR TITLE
fix myuw log propagation

### DIFF
--- a/playbooks/templates/myuw/project_settings-dev.py
+++ b/playbooks/templates/myuw/project_settings-dev.py
@@ -137,23 +137,23 @@ LOGGING = {
             'level': 'INFO',
             'propagate': False,
         },
-        'myuw': {
-            'handlers': ['myuw'],
-            'level': 'INFO',
-            'propagate': True,
-        },
         'card': {
             'handlers': ['card'],
             'level': 'INFO',
-            'propagate': True,
+            'propagate': False,
         },
         'link': {
             'handlers': ['link'],
             'level': 'INFO',
-            'propagate': True,
+            'propagate': False,
         },
         'session': {
             'handlers': ['session'],
+            'level': 'INFO',
+            'propagate': False,
+        },
+        'myuw': {
+            'handlers': ['myuw'],
             'level': 'INFO',
             'propagate': True,
         },

--- a/playbooks/templates/myuw/project_settings.py
+++ b/playbooks/templates/myuw/project_settings.py
@@ -175,23 +175,23 @@ LOGGING = {
             'level': 'INFO',
             'propagate': False,
         },
-        'myuw': {
-            'handlers': ['myuw'],
-            'level': 'INFO',
-            'propagate': True,
-        },
         'card': {
             'handlers': ['card'],
             'level': 'INFO',
-            'propagate': True,
+            'propagate': False,
         },
         'link': {
             'handlers': ['link'],
             'level': 'INFO',
-            'propagate': True,
+            'propagate': False,
         },
         'session': {
             'handlers': ['session'],
+            'level': 'INFO',
+            'propagate': False,
+        },
+        'myuw': {
+            'handlers': ['myuw'],
             'level': 'INFO',
             'propagate': True,
         },


### PR DESCRIPTION
INFO 30 11:23:12 {u'level': u'INFO', u'url': u'https://my-test.s.uw.edu/', u'timestamp': 1535653390363, u'logger': u'link', 'session_key': 'b8bd95ef46a37d744cbf05f926c81ceb', u'message': u'{"href":"/textbooks/2018,autumn","action":"view","source_card":"TextbookCard"}'} [link]
INFO 30 11:23:16 {u'level': u'INFO', u'url': u'https://my-test.s.uw.edu/', u'timestamp': 1535653394779, u'logger': u'card', 'session_key': 'b8bd95ef46a37d744cbf05f926c81ceb', u'message': u'{"action":"loaded","card_name":"AccountSummaryCard","on_screen":true,"screen_width":1529,"screen_height":1277}'} [card]
should not appear in myuw log. They have separate log files