### PR TITLE
Adding retry and delay policy to CDN deploy

### DIFF
--- a/playbooks/includes/cdn-statics-deploy.yml
+++ b/playbooks/includes/cdn-statics-deploy.yml
@@ -5,6 +5,8 @@
       with_items:
           - aca-cdn-web01.s.uw.edu
           - aca-cdn-web02.s.uw.edu
+      retries: 3
+      delay: 10
 
     - command: rsync -aze "ssh -i {{ base_dir }}/aca-cdn-ssh.key" {{ base_dir }}/static/{{ current_build_value }} acahttp@{{ item }}:/data/cdn/cdn/{{ aca_cdn_path }}/
       with_items:


### PR DESCRIPTION
Our CDN deploys have been failing regulary - this should provide an opportunity to retry and give it a delay so that we're not overwhelming the host